### PR TITLE
Added file encoding specs, required by some systems

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,16 @@
 					</execution>
 				</executions>
 			</plugin>
+			<!-- Configuring file encoding -->
+			<plugin>
+			  <groupId>org.apache.maven.plugins</groupId>
+			  <artifactId>maven-compiler-plugin</artifactId>
+			  <configuration>
+			    <source>1.7</source>
+			    <target>1.7</target>
+			    <encoding>ISO-8859-1</encoding>
+			  </configuration>
+			</plugin>
 		</plugins>
 
 	</build>


### PR DESCRIPTION
This will save some users time for configuring file encodings. In cases where this is not necessary having this will prove no harm.